### PR TITLE
Add elm-review check and cache elm dependencies for ui

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -244,7 +244,15 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
-          
+
+      - name: Cache ~/.elm
+        if: "${{ steps.values.outputs.ui == 'true'}}"
+        id: cache-elm
+        uses: actions/cache@v2
+        with:
+          path: ~/.elm
+          key: elm-${{ hashFiles('elm.json', 'review/elm.json') }}
+
       - name: Cache Node Modules
         if: "${{ steps.values.outputs.envconfigservice == 'true'}}"
         id: cache-node
@@ -314,7 +322,11 @@ jobs:
           npx prettier --check '{config,server,src/static}/**/*.{css,html,js,json,ts}'
           npx elm-format src --validate
           npm run build
-          
+
+      - name: Run elm-review
+        if: "${{ steps.values.outputs.ui == 'true'}}"
+        run: npx elm-review
+
       - name: code coverage
         if: "${{ steps.values.outputs.code_coverage == 'true'}}"
         run: |


### PR DESCRIPTION
1. Cache elm dependencies so that we don't have to re-download them on every build if they have not changed
2. Run elm-review to prevent code from being merged that does not pass the checks